### PR TITLE
20 make check for cmd better

### DIFF
--- a/srcs/commands/parsing.cpp
+++ b/srcs/commands/parsing.cpp
@@ -42,19 +42,13 @@ static void	parsing_cmds(server &serv, message &msg)
  */
 void	check_for_cmds(server &serv, message &msg)
 {
-	std::string	cmds[4] = {"NICK", "PASS", "USER", "PING"};
 
 	std::cout << "MSG:" << msg.text << '|' << std::endl;
-	for (int i = 0; i != 3; ++i)
-	{
-		if (msg.text.find(cmds[i]) != std::string::npos)
-		{
-			parsing_cmds(serv, msg);
-			if (msg.target.empty() == false)
-				break ;
-			std::cout << "CMD FOUND :" << msg.cmd.name << std::endl;
-			(serv.*serv.commands[i])(msg);
-			break ;
-		}
-	}
+	parsing_cmds(serv, msg);
+	if (msg.target.empty() == false)
+		return ;
+	if (serv.commands.find(msg.cmd.name) == serv.commands.end())
+		return ;
+	std::cout << "CMD FOUND :" << msg.cmd.name << std::endl;
+	(serv.*serv.commands[msg.cmd.name])(msg);
 }

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -39,10 +39,10 @@ server::server(int new_port, char *new_pass): _port(new_port), _pass(new_pass)
 		return ;
 	}
 
-	commands[0] = &server::nick;
-	commands[1] = &server::pass;
-	commands[2] = &server::user;
-	commands[3] = &server::ping;
+	commands["PASS"] = &server::pass;
+	commands["NICK"] = &server::nick;
+	commands["USER"] = &server::user;
+	commands["PING"] = &server::ping;
 }
 
 server::server(const server &cpy)

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -388,4 +388,5 @@ void	server::ping(message &msg)
 	msg.text.append(SERVERNAME);
 	msg.text.append(" ");
 	msg.text.append(msg.cmd.params);
+	msg.text.append("\r\n");
 }

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -82,8 +82,10 @@ public:
 	fd_set	get_read_fds() const;
 	fd_set	get_write_fds() const;
 
+
 	// command function pointer
-	void	(server::*commands[10])(message &) ;
+	typedef void(server::*command)(message &);
+	std::map<std::string, command>	commands;
 
 	// commands
 	void	error_message(message &msg, std::string prefix, std::string error);


### PR DESCRIPTION
Commands methods are now registered in a std::map<std::string, function>

This is to avoid wasting time with multiple ifs or with for loops on std::string array.
Using the binary tree of std::map, we're also being more efficient. Less iterations.

This behaviour has been tested with both "nc -C" and "irssi".