### PR TITLE
Rpl msg source empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,15 @@ IFLAGS = $(foreach dir, $(SRC_DIR), -I$(dir))
 
 vpath %.cpp $(foreach dir, $(SRC_DIR), $(dir):)
 
+# TODO : rearange the file varaibles, this isn't great
 SERVER = Server.cpp server_loop.cpp Client.cpp
 
 CHANNEL = Channel.cpp
 
 MESSAGES = Message.cpp receive_messages.cpp send_messages.cpp
 
-CMDS = parsing.cpp Pass.cpp Nick.cpp User.cpp Oper.cpp Ping.cpp Join.cpp Privmsg.cpp
+CMDS = parsing.cpp Pass.cpp Nick.cpp User.cpp Oper.cpp Ping.cpp Join.cpp Privmsg.cpp \
+	Part.cpp
 
 SRC = main.cpp $(SERVER) $(CHANNEL) $(CMDS) $(MESSAGES)
 

--- a/srcs/channel/Channel.hpp
+++ b/srcs/channel/Channel.hpp
@@ -9,6 +9,7 @@ class Channel
 {
 friend class Server;
 friend struct Join;
+friend struct Part;
 private:
 	enum ClientStatus
 	{

--- a/srcs/commands/channel/Part.cpp
+++ b/srcs/commands/channel/Part.cpp
@@ -1,0 +1,64 @@
+#include "Part.hpp"
+
+Part::Part(Server &p_serv): ICommand(p_serv)
+{}
+
+// TODO : why do we need to check if msg.cmd_param.empty() == true ?
+void	Part::execute(Message &msg)
+{
+	std::string	reason;
+
+	if (msg.cmd_param.find(" ") != std::string::npos)
+	{
+		reason = msg.cmd_param.substr(msg.cmd_param.find(" ") + 1, msg.cmd_param.size());
+		msg.cmd_param = msg.cmd_param.substr(0, msg.cmd_param.find(" "));
+	}
+	std::cout << "reason [" << reason << "]\n";
+	std::cout << "original [" << msg.cmd_param << "]\n";
+	split_channels(msg.cmd_param);
+	for (std::vector<std::string>::iterator print = channels.begin() ;
+		print != channels.end() ; ++print)
+	{
+		std::cout << "[" << *print << "]";
+	}
+	std::cout << std::endl;
+	if (msg.cmd_param.empty() == true)
+	{
+		channels.back().append(",");
+		return (msg.reply_format(ERR_NOSUCHCHANNEL, channels.back(), serv.get_socket()));
+	}
+}
+
+void	Part::split_channels(std::string &p_params)
+{
+	size_t	comma = p_params.find(',');
+
+	channels.clear();
+	if (comma == std::string::npos)
+	{
+		channels.push_back(p_params);
+		return ;
+	}
+	while (comma != std::string::npos)
+	{
+		channels.push_back(p_params.substr(0, comma));
+		p_params.erase(0, comma + 1);
+		comma = p_params.find(',');
+	}
+	if (p_params.empty() == false)
+		channels.push_back(p_params);
+}
+
+void	part_loop_check(Message *msg)
+{
+
+	for (std::vector<std::string>::iterator it = channels.begin();
+		it != channels.end(); ++it)
+	{
+		if (serv._channel_list.find(*it) == serv._channel_list.end())
+		{
+			Message	error(msg.get_emitter());
+			error.reply_format(ERR_NOSUCH_CHANNEL)
+		}
+	}
+}

--- a/srcs/commands/channel/Part.cpp
+++ b/srcs/commands/channel/Part.cpp
@@ -13,20 +13,13 @@ void	Part::execute(Message &msg)
 		reason = msg.cmd_param.substr(msg.cmd_param.find(" ") + 1, msg.cmd_param.size());
 		msg.cmd_param = msg.cmd_param.substr(0, msg.cmd_param.find(" "));
 	}
-	std::cout << "reason [" << reason << "]\n";
-	std::cout << "original [" << msg.cmd_param << "]\n";
 	split_channels(msg.cmd_param);
-	for (std::vector<std::string>::iterator print = channels.begin() ;
-		print != channels.end() ; ++print)
-	{
-		std::cout << "[" << *print << "]";
-	}
-	std::cout << std::endl;
 	if (msg.cmd_param.empty() == true)
 	{
 		channels.back().append(",");
 		return (msg.reply_format(ERR_NOSUCHCHANNEL, channels.back(), serv.get_socket()));
 	}
+	loop_check(&msg);
 }
 
 void	Part::split_channels(std::string &p_params)
@@ -59,6 +52,7 @@ void	Part::loop_check(Message *msg)
 		if (serv._channel_list.find(*it) == serv._channel_list.end())
 		{
 			error.reply_format(ERR_NOSUCHCHANNEL, *it, serv.get_socket());
+			serv.msgs.push_back(error);
 			continue ;
 		}
 		Channel	*current = &serv._channel_list.find(*it)->second;
@@ -66,6 +60,7 @@ void	Part::loop_check(Message *msg)
 			|| current->_is(current->_clients.find(msg->get_emitter())->second, current->MEMBER) == false)
 		{
 			error.reply_format(ERR_NOTONCHANNEL, *it, serv.get_socket());
+			serv.msgs.push_back(error);
 			continue ;
 		}
 		success_behaviour(msg, current);
@@ -75,18 +70,18 @@ void	Part::loop_check(Message *msg)
 void	Part::success_behaviour(Message *msg, Channel *current)
 {
 	Message	warning_client_leaving(msg->get_emitter());
-	std::pair<int, int>	*client_cpy = current->_clients.find(msg->get_emitter());
+	int	*client_bitfield = &current->_clients.find(msg->get_emitter())->second;
 
-	client_cpy->second = client_cpy->second ^ current->MEMBER;
-	if (client_cpy->second == 0)
-		current->_clients.erase(current->.find(msg->get_emitter()));
-	if (current->_is(client_cpy->second, current->CHANOP) == true)
+	*client_bitfield = *client_bitfield ^ current->MEMBER;
+	if (client_bitfield == 0)
+		current->_clients.erase(current->_clients.find(msg->get_emitter()));
+	if (current->_is(*client_bitfield, current->CHANOP) == true)
 	{
-		client_cpy->second = client_cpy->second ^ current->CHANOP;
+		*client_bitfield = *client_bitfield ^ current->CHANOP;
 		if (are_there_other_chanops(current) == false)
 			assign_next_chanop(current);
-		if (current->_is(client_cpy->second, current->INVITED) == false)
-			current->_clients.erase(current->.find(msg->get_emitter()));
+		if (current->_is(*client_bitfield, current->INVITED) == false)
+			current->_clients.erase(current->_clients.find(msg->get_emitter()));
 	}
 	warning_client_leaving.reply_format(RPL_PART, current->_name, serv.get_socket());
 	warning_client_leaving.target.clear();
@@ -94,8 +89,10 @@ void	Part::success_behaviour(Message *msg, Channel *current)
 		it != current->_clients.end() ; ++it)
 	{
 		if (current->_is(it->second, current->MEMBER) == true)
-			warning_client_leaving.target.push_back(it->first);
+			warning_client_leaving.target.insert(it->first);
 	}
+	if (warning_client_leaving.target.empty() == false)
+		serv.msgs.push_back(warning_client_leaving);
 }
 
 void	Part::assign_next_chanop(Channel *current)

--- a/srcs/commands/channel/Part.cpp
+++ b/srcs/commands/channel/Part.cpp
@@ -49,16 +49,75 @@ void	Part::split_channels(std::string &p_params)
 		channels.push_back(p_params);
 }
 
-void	part_loop_check(Message *msg)
+void	Part::loop_check(Message *msg)
 {
+	Message	error(msg->get_emitter());
 
 	for (std::vector<std::string>::iterator it = channels.begin();
 		it != channels.end(); ++it)
 	{
 		if (serv._channel_list.find(*it) == serv._channel_list.end())
 		{
-			Message	error(msg.get_emitter());
-			error.reply_format(ERR_NOSUCH_CHANNEL)
+			error.reply_format(ERR_NOSUCHCHANNEL, *it, serv.get_socket());
+			continue ;
+		}
+		Channel	*current = &serv._channel_list.find(*it)->second;
+		if (current->_clients.find(msg->get_emitter()) == current->_clients.end()
+			|| current->_is(current->_clients.find(msg->get_emitter())->second, current->MEMBER) == false)
+		{
+			error.reply_format(ERR_NOTONCHANNEL, *it, serv.get_socket());
+			continue ;
+		}
+		success_behaviour(msg, current);
+	}
+}
+
+void	Part::success_behaviour(Message *msg, Channel *current)
+{
+	Message	warning_client_leaving(msg->get_emitter());
+	std::pair<int, int>	*client_cpy = current->_clients.find(msg->get_emitter());
+
+	client_cpy->second = client_cpy->second ^ current->MEMBER;
+	if (client_cpy->second == 0)
+		current->_clients.erase(current->.find(msg->get_emitter()));
+	if (current->_is(client_cpy->second, current->CHANOP) == true)
+	{
+		client_cpy->second = client_cpy->second ^ current->CHANOP;
+		if (are_there_other_chanops(current) == false)
+			assign_next_chanop(current);
+		if (current->_is(client_cpy->second, current->INVITED) == false)
+			current->_clients.erase(current->.find(msg->get_emitter()));
+	}
+	warning_client_leaving.reply_format(RPL_PART, current->_name, serv.get_socket());
+	warning_client_leaving.target.clear();
+	for (std::map<int, int>::iterator it = current->_clients.begin() ;
+		it != current->_clients.end() ; ++it)
+	{
+		if (current->_is(it->second, current->MEMBER) == true)
+			warning_client_leaving.target.push_back(it->first);
+	}
+}
+
+void	Part::assign_next_chanop(Channel *current)
+{
+	for (std::map<int, int>::iterator it = current->_clients.begin() ;
+		it != current->_clients.end() ; ++it)
+	{
+		if (current->_is(it->second, current->MEMBER) == true)
+		{
+			it->second = it->second | current->CHANOP;
+			return ;
 		}
 	}
+}
+
+bool	Part::are_there_other_chanops(Channel *current)
+{
+	for (std::map<int, int>::iterator it = current->_clients.begin();
+		it != current->_clients.end(); ++it)
+	{
+		if (current->_is(it->second, current->CHANOP) == true)
+			return (true);
+	}
+	return (false);
 }

--- a/srcs/commands/channel/Part.hpp
+++ b/srcs/commands/channel/Part.hpp
@@ -9,5 +9,11 @@ struct Part : public ICommand
 	Part(Server &p_serv);
 
 	void	execute(Message &msg);
+
+	private :
 	void	split_channels(std::string &p_params);
+	void	loop_check(Message *msg);
+	void	assign_next_chanop(Channel *current);
+	bool	are_there_other_chanops(Channel *current);
+	void	success_behaviour(Message *msg, Channel *current);
 };

--- a/srcs/commands/channel/Part.hpp
+++ b/srcs/commands/channel/Part.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "ICommand.hpp"
+
+struct Part : public ICommand
+{
+	std::vector<std::string>	channels;
+
+	Part(Server &p_serv);
+
+	void	execute(Message &msg);
+	void	split_channels(std::string &p_params);
+};

--- a/srcs/define.hpp
+++ b/srcs/define.hpp
@@ -44,6 +44,7 @@
 //		CUSTOM
 // 			REPLIES
 #define RPL_JOIN ":<client> JOIN <channel>\r\n"
+#define RPL_PART ":<client> PART <channel>\r\n"
 #define RPL_CLIENTLEFT "908 <client> :Client <nick> just left " SERVERNAME ", bye bye\r\n"
 // 			ERRRORS
 #define ERR_CANNOTBECOMEOPER "920 <client> :Operator role already fullfiled\r\n"

--- a/srcs/define.hpp
+++ b/srcs/define.hpp
@@ -35,6 +35,7 @@
 #define ERR_NONICKNAMEGIVEN "431 <client> :No nickname given\r\n"
 #define ERR_ERRONEUSNICKNAME "432 <client> <nick> :Erroneus nickname\r\n"
 #define ERR_NICKNAMEINUSE "433 <client> <nick> :Nickname is already in use\r\n"
+#define ERR_NOTONCHANNEL "442 <client> <channel> :You're not on that channel\r\n"
 #define ERR_NEEDMOREPARAMS "461 <client> <command> :Not enough parameters\r\n"
 #define ERR_ALREADYREGISTRED "462 <client> :You may not reregister\r\n"
 #define ERR_PASSWDMISMATCH "464 <client> :Password incorrect\r\n"

--- a/srcs/ircserv.hpp
+++ b/srcs/ircserv.hpp
@@ -14,6 +14,7 @@
 #include "Privmsg.hpp"
 #include "Oper.hpp"
 #include "Join.hpp"
+#include "Part.hpp"
 #include "Ping.hpp"
 
 // SERVER

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -4,21 +4,14 @@
 
 void	setup_commands(Server &serv)
 {
-	// commands["PASS"] = &Server::pass;
 	serv.register_command<Pass>("PASS");
 	serv.register_command<Nick>("NICK");
 	serv.register_command<User>("USER");
 	serv.register_command<Privmsg>("PRIVMSG");
 	serv.register_command<Oper>("OPER");
 	serv.register_command<Join>("JOIN");
+	serv.register_command<Part>("PART");
 	serv.register_command<Ping>("PING");
-	// commands["NICK"] = &Server::nick;
-	// commands["USER"] = &Server::user;
-	// commands["OPER"] = &Server::oper;
-	// commands["PRIVMSG"] = &Server::privmsg;
-	// commands["JOIN"] = &Server::join;
-	// commands["PING"] = &Server::ping;
-
 }
 
 int	main(int ac, char **av)

--- a/srcs/messages/Message.cpp
+++ b/srcs/messages/Message.cpp
@@ -69,6 +69,7 @@ void	Message::replace_rpl_err_text(std::string replace)
  */
 void	Message::reply_format(std::string reply, std::string replace, int socket)
 {
+	// ! do we really need this ? it feels stale
 	target.clear();
 	target.insert(_emitter);
 

--- a/srcs/messages/Message.hpp
+++ b/srcs/messages/Message.hpp
@@ -18,6 +18,7 @@ class Client;
 class Message
 {
 private:
+	// TODO wouldn't it be more practical if this value was a public const static ?
 	int	_emitter;
 
 	Message();

--- a/srcs/server/Server.hpp
+++ b/srcs/server/Server.hpp
@@ -36,6 +36,7 @@ class Server
 	friend class Part;
 private:
 	// Server authentification
+	// TODO : shouldn't this value be a public const static instead of a private ?
 	int			_port;
 	std::string	_pass;
 

--- a/srcs/server/Server.hpp
+++ b/srcs/server/Server.hpp
@@ -33,6 +33,7 @@ struct ICommand;
 class Server
 {
 	friend class Join;
+	friend class Part;
 private:
 	// Server authentification
 	int			_port;


### PR DESCRIPTION
⚠️  WARNING ⚠️ 
THIS PULL REQUEST MUST BE TREATED AFTER #47 (it changes Part files)

The problem was comming from the message class.
format_reply() was using Message.emitter_name to fill the <client> part of the message.
However this variable was not always set in the code and my calls of it in JOIN and PART.

The constructor : Message(int emitter)
has therefore been replaced by : Message(int p_emitter, std::string p_name)

this avoids any further possible errors that might occur.
Usually this is not an issue as the originated message (created in receive_message.cpp) uses the constructor "Message(const Client &emitter)" which sets emitter_name correctly.