### PR TITLE
Topic command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ MESSAGES = Message.cpp receive_messages.cpp send_messages.cpp parsing.cpp
 CMD_CONNECTION = Pass.cpp Nick.cpp User.cpp
 CMD_MESSAGE = Privmsg.cpp
 CMD_MANAGEMENT = Oper.cpp
-CMD_CHANNEL = Join.cpp Part.cpp
+CMD_CHANNEL = Join.cpp Part.cpp Topic.cpp
 CMD_MISC = Ping.cpp
 
 SRC = main.cpp $(SERVER) $(CHANNEL) $(MESSAGES) \

--- a/srcs/channel/Channel.hpp
+++ b/srcs/channel/Channel.hpp
@@ -10,6 +10,7 @@ class Channel
 friend class Server;
 friend struct Join;
 friend struct Part;
+friend struct Topic;
 private:
 	enum ClientStatus
 	{
@@ -20,6 +21,8 @@ private:
 
 	std::string			_name;
 	std::string			_topic;
+	std::string			_topic_date;
+	std::string			_topic_author;
 	std::string			_key;
 	bool				_is_invite_only;
 	std::map<int, int>	_clients;

--- a/srcs/commands/channel/Join.cpp
+++ b/srcs/commands/channel/Join.cpp
@@ -166,7 +166,15 @@ void	Join::new_chan_member_sucess(Message msg, std::string chan)
 	new_member_warning.target.clear();
 
 	if (serv._channel_list.find(chan)->second._topic.empty() == false)
-		replies.push_back(serv._channel_list.find(chan)->second._topic);
+	{
+		replies.push_back(RPL_TOPIC);
+		replies.push_back(RPL_TOPICWHOTIME);
+		replace.push_back(chan);
+		replace.push_back(serv._channel_list.find(chan)->second._topic);
+		replace.push_back(chan);
+		replace.push_back(serv._channel_list.find(chan)->second._topic_author);
+		replace.push_back(serv._channel_list.find(chan)->second._topic_date);
+	}
 	replies.push_back(RPL_NAMREPLY);
 	// TODO : check when modes is implemented that there isnt a if here to be added
 	replace.push_back("=");

--- a/srcs/commands/channel/Join.cpp
+++ b/srcs/commands/channel/Join.cpp
@@ -7,6 +7,8 @@ void	Join::execute(Message &msg)
 {
 	std::string					tmp;
 
+	if (msg.cmd_param.compare("0") == 0)
+		return (special_argument(msg));
 	if (msg.cmd_param.find_first_of(" ") != msg.cmd_param.find_last_of(" "))
 		return (join_space_error(msg));
 	if (msg.cmd_param.find(' ') != std::string::npos)
@@ -17,13 +19,27 @@ void	Join::execute(Message &msg)
 		msg.cmd_param.erase(msg.cmd_param.find(' '), msg.cmd_param.size());
 	}
 	channels = split_join_cmd(msg.cmd_param);
-	// for (std::vector<std::string>::iterator it = channels.begin(); it != channels.end(); ++it)
-	// {
-	// 	std::cout << "chan->[" << *it << "]\n";
-	// }
 	if (msg.cmd_param.empty() == true)
 		channels.push_back("");
 	join_channel(msg);
+}
+
+void	Join::special_argument(Message &msg)
+{
+	msg.cmd_param.clear();
+	for (std::map<std::string, Channel>::iterator it = serv._channel_list.begin();
+		it != serv._channel_list.end(); ++it)
+	{
+		if (it->second._clients.find(msg.get_emitter()) != it->second._clients.end())
+		{
+			if (msg.cmd_param.empty() == true)
+				msg.cmd_param = it->first;
+			else
+				msg.cmd_param.append("," + it->first);
+		}
+	}
+	if (msg.cmd_param.empty() == false)
+		serv.commands["PART"]->execute(msg);
 }
 
 void	Join::join_space_error(Message &msg)

--- a/srcs/commands/channel/Join.hpp
+++ b/srcs/commands/channel/Join.hpp
@@ -54,5 +54,6 @@ struct Join : public ICommand
 	 */
 	void	join_check_existing_chan(Message msg, Channel *channel);
 	void	new_chan_member_sucess(Message msg, std::string chan);
+	void	special_argument(Message &msg);
 };
 

--- a/srcs/commands/channel/Part.cpp
+++ b/srcs/commands/channel/Part.cpp
@@ -85,6 +85,7 @@ void	Part::success_behaviour(Message *msg, Channel *current)
 		return ;
 	if (client_bitfield == 0)
 		current->_clients.erase(current->_clients.find(msg->get_emitter()));
+	// TODO :send message to new CHANOP to warn him he is the new CHANOP
 	if (current->_is(*client_bitfield, current->CHANOP) == true)
 	{
 		*client_bitfield = *client_bitfield ^ current->CHANOP;

--- a/srcs/commands/channel/Topic.cpp
+++ b/srcs/commands/channel/Topic.cpp
@@ -1,0 +1,65 @@
+#include "Topic.hpp"
+
+Topic::Topic(Server &p_server): ICommand(p_server)
+{}
+
+void	Topic::execute(Message &msg)
+{
+	std::string	new_topic;
+
+	if (msg.cmd_param.empty() == true)
+		return (msg.reply_format(ERR_NOSUCHCHANNEL, "", serv.socket_id));
+	if (serv._channel_list.find(msg.cmd_param.substr(0, msg.cmd_param.find(' '))) == serv._channel_list.end())
+		return (msg.reply_format(ERR_NOSUCHCHANNEL, msg.cmd_param.substr(0, msg.cmd_param.find(' ')), serv.socket_id));
+	if (msg.cmd_param.find(':') == std::string::npos)
+		return (return_topic(msg, &serv._channel_list.find(msg.cmd_param)->second));
+
+	Channel		*channel = &serv._channel_list.find(msg.cmd_param.substr(0, msg.cmd_param.find(':') - 1))->second;
+
+	std::cout << "CHAN [" << channel->_name << "]\n";
+	new_topic = msg.cmd_param.substr(msg.cmd_param.find(':') + 1, msg.cmd_param.size());
+	std::cout << "TOPIC [" << new_topic << "]\n";
+	if (channel->_clients.find(msg.get_emitter()) == channel->_clients.end())
+		return (msg.reply_format(ERR_NOTONCHANNEL, channel->_name, serv.socket_id));
+	if (channel->_is(channel->_clients.find(msg.get_emitter())->second, channel->CHANOP) == false)
+		return (msg.reply_format(ERR_CHANOPRIVSNEEDED, channel->_name, serv.socket_id));
+	change_topic(msg, channel, new_topic);
+}
+
+void	Topic::return_topic(Message &msg, Channel *channel)
+{
+	std::vector<std::string>	replies;
+	std::vector<std::string>	replace;
+
+	replies.push_back(RPL_TOPIC);
+	replies.push_back(RPL_TOPICWHOTIME);
+
+	replace.push_back(channel->_name);
+	replace.push_back(channel->_topic);
+
+	replace.push_back(channel->_name);
+	replace.push_back(channel->_topic_author);
+	replace.push_back(channel->_topic_date);
+	msg.reply_format(replies, replace);
+}
+
+void	Topic::change_topic(Message &msg, Channel *channel, std::string new_topic)
+{
+	std::time_t					time = std::time(0);
+	std::tm						*now = std::localtime(&time);
+	std::stringstream			ss;
+
+	ss << (now->tm_year + 1900) << '-' << (now->tm_mon + 1) << '-' << now->tm_mday;
+	ss >> channel->_topic_date;
+	channel->_topic_author = serv.client_list.find(msg.get_emitter())->second.nickname;
+	channel->_topic = new_topic;
+
+	return_topic(msg, channel);
+	msg.target.clear();
+
+	for (std::map<int, int>::iterator it = channel->_clients.begin();
+		it != channel->_clients.end(); ++it)
+	{
+		msg.target.insert(it->first);
+	}
+}

--- a/srcs/commands/channel/Topic.hpp
+++ b/srcs/commands/channel/Topic.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <ctime>
+#include <sstream>
+
+#include "ICommand.hpp"
+
+struct Topic : public ICommand
+{
+	Topic(Server &p_server);
+
+	void	execute(Message &msg);
+	private :
+	void	return_topic(Message &msg, Channel *channel);
+	void	change_topic(Message &msg, Channel *channel, std::string new_topic);
+};

--- a/srcs/define.hpp
+++ b/srcs/define.hpp
@@ -42,6 +42,7 @@
 #define ERR_PASSWDMISMATCH "464 <client> :Password incorrect\r\n"
 #define ERR_INVITEONLYCHAN "473 <client> <channel> :Cannot join channel (+i)\r\n"
 #define ERR_BADCHANNELKEY "475 <client> <channel> :Cannot join channel (+k)\r\n"
+#define ERR_CHANOPRIVSNEEDED "482 <client> <channel> :You're not channel operator\r\n"
 //		CUSTOM
 // 			REPLIES
 #define RPL_JOIN ":<client> JOIN <channel>\r\n"

--- a/srcs/ircserv.hpp
+++ b/srcs/ircserv.hpp
@@ -15,6 +15,7 @@
 #include "Oper.hpp"
 #include "Join.hpp"
 #include "Part.hpp"
+#include "Topic.hpp"
 #include "Ping.hpp"
 
 // SERVER

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -11,6 +11,7 @@ void	setup_commands(Server &serv)
 	serv.register_command<Oper>("OPER");
 	serv.register_command<Join>("JOIN");
 	serv.register_command<Part>("PART");
+	serv.register_command<Topic>("TOPIC");
 	serv.register_command<Ping>("PING");
 }
 

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -164,21 +164,26 @@ void	Server::del_client(int fd)
 {
 	Message	part_msg(client_list.find(fd)->second);
 	// delete client from messages
-	del_client_from_msgs(fd);
 	// delete client from channels
 	for (std::map<std::string, Channel>::iterator it = _channel_list.begin();
 		it != _channel_list.end(); ++it)
 	{
 		if (it->second._clients.find(fd) != it->second._clients.end())
 		{
-			if (part_msg.cmd_param.empty() == true)
-				part_msg.cmd_param = it->first;
+			if (it->second._is(it->second._clients.find(fd)->second, it->second.MEMBER) == true)
+			{
+				if (part_msg.cmd_param.empty() == true)
+					part_msg.cmd_param = it->first;
+				else
+					part_msg.cmd_param.append("," + it->first);
+			}
 			else
-				part_msg.cmd_param.append("," + it->first);
+				it->second._clients.erase(it->second._clients.find(fd));
 		}
 	}
 	if (part_msg.cmd_param.empty() == false)
 		commands["PART"]->execute(part_msg);
+	del_client_from_msgs(fd);
 	close(fd);
 	client_list.erase(client_list.find(fd));
 	std::cout << "BYE BYE CLIENT" << std::endl;

--- a/srcs/server/Server.hpp
+++ b/srcs/server/Server.hpp
@@ -30,8 +30,10 @@ struct ICommand;
 
 class Server
 {
-	friend class Join;
-	friend class Part;
+	friend struct Join;
+	friend struct Part;
+	// TODO :make a function to get a channel with a specific name
+	friend struct Topic;
 private:
 
 	// Server socket creation and identification


### PR DESCRIPTION
the topic command has been implemented :

A channel operator can set the channel topic with : "TOPIC #channel-name :new topic here"
Any client can access a channel topic with : "TOPIC #channel-name"
When the topic of a channel is modified, all clients who are part of the channel will be notified, including the chanop who modified the topic.
When a client joins a channel on which the topic is set, the topic will now be sent with the other join replies.
A channel topic can be emptied by the chanop by sending : "TOPIC #channel-name :"

Some TODO comments were added, they were not related to the branch directly so i didn't treat them yet