### PR TITLE
Privmsg channel

### DIFF
--- a/srcs/channel/Channel.hpp
+++ b/srcs/channel/Channel.hpp
@@ -14,6 +14,7 @@ friend struct Invite;
 friend struct Topic;
 friend struct Kick;
 friend struct Quit;
+friend struct Privmsg;
 
 private:
 	enum ClientStatus

--- a/srcs/commands/message/Privmsg.hpp
+++ b/srcs/commands/message/Privmsg.hpp
@@ -14,4 +14,5 @@ struct Privmsg : public ICommand
 	Privmsg(Server &p_serv);
 
 	void	execute(Message &msg);
+	void	add_correct_targets(Server& serv, Message& msg, std::map<std::string, int>& targets);
 };

--- a/srcs/define.hpp
+++ b/srcs/define.hpp
@@ -35,6 +35,7 @@
 #define ERR_TOOMANYPARAM "400 <client> <command> :Too many parameters\r\n"
 #define ERR_NOSUCHNICK "401 <client> :<nickname> :No such nick/channel\r\n"
 #define ERR_NOSUCHCHANNEL "403 <client> <channel> :No such channel\r\n"
+#define ERR_CANNOTSENDTOCHAN "404 <client> <channel> :Cannot send to channel\r\n"
 #define ERR_NOTEXTTOSEND "412 <client> :No text to send\r\n"
 #define ERR_NONICKNAMEGIVEN "431 <client> :No nickname given\r\n"
 #define ERR_ERRONEUSNICKNAME "432 <client> <nick> :Erroneus nickname\r\n"


### PR DESCRIPTION
Finished implementing Privmsg for channels (#24)

This feature allows a client to send messages to a channel if they are a part of said channel.
If they are not an error will be returned; 